### PR TITLE
new orders now show proper order details in order show

### DIFF
--- a/app/controllers/order_controller.rb
+++ b/app/controllers/order_controller.rb
@@ -38,7 +38,7 @@ class OrderController < ApplicationController
   get '/orders/history' do
     # collect the user's orders
     @orders = Order.all.find_all{|order| order["user_id"] == current_user.id }
-
+    # @orders = current_user.orders
     # show user's order history
     erb :"/orders/history"
   end
@@ -87,6 +87,7 @@ class OrderController < ApplicationController
     end
     # otherwise go to preview page
     redirect "/orders/preview"
+
   end
 
   patch "/orders/edit" do
@@ -117,13 +118,6 @@ class OrderController < ApplicationController
   end
   
   post "/orders/complete" do
-    # after user confirms order, remove order number from @user
-    @user.order_ids = nil
-    @user.save
-    Burrito.all.each do |burrito|
-      burrito.quantity = nil
-      burrito.save
-    end
     # go back to user index page
     redirect "/users/index"
   end

--- a/app/views/orders/history.erb
+++ b/app/views/orders/history.erb
@@ -2,6 +2,7 @@
 Here are your Orders - click on the Order # to see details
 <br><br><br>
 <% @orders.each do |order| %>
+<%binding.pry%>
   <p><a href="/orders/<%= order.id %>">Order #: <%= order.id %></a> Store:  <%= @store.store_name %><br> 
   Order Total: $<%= '%.2f' % order.order_total %><br>
   Ordered by: <%= @user.name %></p> <br>

--- a/app/views/orders/history.erb
+++ b/app/views/orders/history.erb
@@ -2,7 +2,6 @@
 Here are your Orders - click on the Order # to see details
 <br><br><br>
 <% @orders.each do |order| %>
-<%binding.pry%>
   <p><a href="/orders/<%= order.id %>">Order #: <%= order.id %></a> Store:  <%= @store.store_name %><br> 
   Order Total: $<%= '%.2f' % order.order_total %><br>
   Ordered by: <%= @user.name %></p> <br>

--- a/app/views/orders/show.erb
+++ b/app/views/orders/show.erb
@@ -3,12 +3,13 @@ Order Information
 <p>Order #: <%= params[:id] %></a> Store: <%= @store.store_name %><br> 
 Order Total: $<%=  '%.2f' % @order.order_total %><br>
 Ordered by: <%= @user.name %></p> 
+<%binding.pry%>
 
 <%# list order items %>
-<%#binding.pry%>
 <%# I had to add in an item count due to how I am saving the quantity%>
-<% item_count = 0%>
+<% item_count = 1%>
 <%@order.burritos.each do |burrito| %>
+<%binding.pry%>
   <%= burrito.id %>: <%= burrito.name %>, Quantity: <%= @order.order_burritos[item_count].quantity %>, Price: $<%=  '%.2f' % burrito.price %><br>
   Item Total: $<%=  '%.2f' % (@order.order_burritos[item_count].quantity  * burrito.price) %><br><br>
   <%item_count += 1%>

--- a/app/views/orders/show.erb
+++ b/app/views/orders/show.erb
@@ -3,13 +3,11 @@ Order Information
 <p>Order #: <%= params[:id] %></a> Store: <%= @store.store_name %><br> 
 Order Total: $<%=  '%.2f' % @order.order_total %><br>
 Ordered by: <%= @user.name %></p> 
-<%binding.pry%>
 
 <%# list order items %>
 <%# I had to add in an item count due to how I am saving the quantity%>
 <% item_count = 1%>
 <%@order.burritos.each do |burrito| %>
-<%binding.pry%>
   <%= burrito.id %>: <%= burrito.name %>, Quantity: <%= @order.order_burritos[item_count].quantity %>, Price: $<%=  '%.2f' % burrito.price %><br>
   Item Total: $<%=  '%.2f' % (@order.order_burritos[item_count].quantity  * burrito.price) %><br><br>
   <%item_count += 1%>


### PR DESCRIPTION
Fixed error - order details were deleted from join table order_burrito. 

However:
When creating an order, an incomplete row is inserted into the order_burrito table.  This is incompatible with older orders.  Further refactoring is required to get rid of the incomplete row.  it is currently set to display new orders correctly - Otherwise - it functions as needed.